### PR TITLE
Fix Vercel output dir

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "buildCommand": "npm run build",
-  "outputDirectory": "public"
+  "outputDirectory": "dist/public"
 }


### PR DESCRIPTION
## Summary
- update the Vercel config to look for the actual build output

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'jest')*

------
https://chatgpt.com/codex/tasks/task_e_686b1c7576e88331a737b35fb42b6822